### PR TITLE
fix(bot): :bug: Fix `.nft create` bug

### DIFF
--- a/packages/custom-types/src/server/ServerError.ts
+++ b/packages/custom-types/src/server/ServerError.ts
@@ -8,7 +8,7 @@ const ServerError = sparseType({
     code: i.string,
     title: i.string,
     message: optional(i.string),
-    details: i.record(i.string, i.string)
+    details: optional(i.record(i.string, i.string))
 })
 
 type ServerError = i.TypeOf<typeof ServerError>


### PR DESCRIPTION
NFT was owned by the user, but the bot would output `unknown error uploading NFT`
Turns out the ServerError was incorrectly parsing the data